### PR TITLE
*.sync files should not be deleted, since it is used as a temporary file by CmisSync sync operation

### DIFF
--- a/CmisSync/TestLibrary/CmisSyncTests.cs
+++ b/CmisSync/TestLibrary/CmisSyncTests.cs
@@ -360,6 +360,11 @@ namespace TestLibrary
                 DirectoryInfo localDirectoryInfo = new DirectoryInfo(localDirectory);
                 foreach (FileInfo file in localDirectoryInfo.GetFiles())
                 {
+                    if (file.Name.EndsWith(".sync"))
+                    {
+                        continue;
+                    }
+
                     try
                     {
                         file.Delete();


### PR DESCRIPTION
... by CmisSync sync operation
